### PR TITLE
fix: Clean up unintended changes from timeout PR

### DIFF
--- a/src/DaytonaClient.php
+++ b/src/DaytonaClient.php
@@ -411,7 +411,6 @@ class DaytonaClient
             }
 
             $response = $this->client()->post("toolbox/{$sandboxId}/toolbox/git/clone", $payload);
-            ray($response->json())->blue();
 
             if (! $response->successful()) {
                 throw ApiException::fromResponse($response, 'clone repository');

--- a/src/DaytonaClient.php
+++ b/src/DaytonaClient.php
@@ -393,7 +393,6 @@ class DaytonaClient
 
             $payload = [
                 'url' => $url,
-                // 'path' => $path,
             ];
 
             if ($path) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -18,8 +18,6 @@ class ServiceProvider extends BaseServiceProvider
         );
 
         $this->app->singleton(Config::class, function (Application $app) {
-            ray('here');
-
             return new Config(
                 apiKey: config('daytona.api_key'),
                 apiUrl: config('daytona.api_url'),

--- a/tests-integration/IntegrationTestCase.php
+++ b/tests-integration/IntegrationTestCase.php
@@ -9,7 +9,6 @@ class IntegrationTestCase extends Orchestra
 {
     protected function getBasePath(): string
     {
-        // Tell Orchestra where to find the package root
         return __DIR__.'/..';
     }
 
@@ -22,7 +21,5 @@ class IntegrationTestCase extends Orchestra
 
     protected function getEnvironmentSetUp($app): void
     {
-        // Orchestra Testbench will automatically load .env.testing
-        // when APP_ENV is set to 'testing'
     }
 }

--- a/tests-integration/IntegrationTestCase.php
+++ b/tests-integration/IntegrationTestCase.php
@@ -19,7 +19,5 @@ class IntegrationTestCase extends Orchestra
         ];
     }
 
-    protected function getEnvironmentSetUp($app): void
-    {
-    }
+    protected function getEnvironmentSetUp($app): void {}
 }

--- a/tests/DaytonaClientTest.php
+++ b/tests/DaytonaClientTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use ElliottLawson\Daytona\DaytonaClient;
+use ElliottLawson\Daytona\DTOs\CommandResponse;
 use ElliottLawson\Daytona\DTOs\Config;
 use ElliottLawson\Daytona\Exceptions\ConfigurationException;
 use Illuminate\Support\Facades\Http;
@@ -76,7 +77,7 @@ it('passes command timeout to HTTP client with proper conversion', function () {
 
     $response = $client->executeCommand('sandbox-123', 'long-running-command', null, null, 60000);
 
-    expect($response)->toBeInstanceOf(\ElliottLawson\Daytona\DTOs\CommandResponse::class);
+    expect($response)->toBeInstanceOf(CommandResponse::class);
     expect($response->exitCode)->toBe(0);
     expect($response->output)->toBe('Command output');
 
@@ -105,7 +106,7 @@ it('uses default timeout when no command timeout is specified', function () {
 
     $response = $client->executeCommand('sandbox-123', 'quick-command');
 
-    expect($response)->toBeInstanceOf(\ElliottLawson\Daytona\DTOs\CommandResponse::class);
+    expect($response)->toBeInstanceOf(CommandResponse::class);
     expect($response->exitCode)->toBe(0);
 
     // Verify the request was made without timeout in payload


### PR DESCRIPTION
## Description

This PR cleans up unintended changes that were included in the timeout fix PR.

## Changes

### Code Cleanup
- Removed ray debugging calls from ServiceProvider.php and DaytonaClient.php
- Removed multiple ray calls from SandboxApiTest.php

### Test Improvements
- Added proper imports for CommandResponse and SandboxResponse in test files
- Replaced inline class references with proper imports
- Marked the manual Git operations test as skipped