### PR TITLE
fix: Rename ServiceProvider to DaytonaServiceProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require elliottlawson/daytona-php-sdk
 
 2. Publish the configuration file:
 ```bash
-php artisan vendor:publish --provider="ElliottLawson\Daytona\ServiceProvider" --tag="daytona-config"
+php artisan vendor:publish --provider="ElliottLawson\Daytona\DaytonaServiceProvider" --tag="daytona-config"
 ```
 
 3. Add your Daytona credentials to your `.env` file:

--- a/src/DaytonaServiceProvider.php
+++ b/src/DaytonaServiceProvider.php
@@ -6,7 +6,7 @@ use ElliottLawson\Daytona\DTOs\Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
-class ServiceProvider extends BaseServiceProvider
+class DaytonaServiceProvider extends BaseServiceProvider
 {
     /**
      * Register services.

--- a/tests-integration/IntegrationTestCase.php
+++ b/tests-integration/IntegrationTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use ElliottLawson\Daytona\ServiceProvider;
+use ElliottLawson\Daytona\DaytonaServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class IntegrationTestCase extends Orchestra
@@ -16,7 +16,7 @@ class IntegrationTestCase extends Orchestra
     protected function getPackageProviders($app): array
     {
         return [
-            ServiceProvider::class,
+            DaytonaServiceProvider::class,
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace ElliottLawson\Daytona\Tests;
 
-use ElliottLawson\Daytona\ServiceProvider;
+use ElliottLawson\Daytona\DaytonaServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -10,7 +10,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app): array
     {
         return [
-            ServiceProvider::class,
+            DaytonaServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Description

This PR fixes an issue discovered after merging PR #1 where the composer.json was still referencing the old service provider name, but the actual class had been renamed to just ServiceProvider.

## Problem

After the changes in PR #1, there was a mismatch:
- The ServiceProvider class was renamed from DaytonaServiceProvider to ServiceProvider
- However, composer.json was still registering ElliottLawson\Daytona\DaytonaServiceProvider
- This would cause Laravel package auto-discovery to fail

## Solution

This PR reverts the service provider name back to DaytonaServiceProvider for clarity and consistency:
- Renamed the class from ServiceProvider to DaytonaServiceProvider
- Renamed the file from ServiceProvider.php to DaytonaServiceProvider.php
- Updated all imports in test files
- Updated the README vendor:publish command

## Benefits

- Clear, descriptive naming that follows Laravel conventions
- Consistency between the class name and composer.json registration
- No breaking changes for existing users

## Testing

- All tests pass
- Laravel auto-discovery works correctly