### PR TITLE
Fix command response exit code handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ if ($result->isSuccessful()) {
 $result = $sandbox->exec('composer install');
 echo $result->output;
 
+// Note about exit codes:
+// - Exit code 0 means success
+// - Exit codes 1-255 indicate various error conditions
+// - Exit code -1 means the actual exit code couldn't be determined by Daytona
+if (!$result->hasKnownExitCode()) {
+    echo "Warning: Exit code is unknown";
+}
+
 // Execute with specific working directory
 $result = $sandbox->exec('ls -la', '/workspace');
 

--- a/src/CommandResponseParser.php
+++ b/src/CommandResponseParser.php
@@ -10,6 +10,10 @@ class CommandResponseParser
      * Parse command execution response from Daytona API.
      *
      * Handles various response formats that Daytona might return.
+     * 
+     * Note: When Daytona returns exitCode -1, it means the actual exit code
+     * couldn't be determined. Valid bash exit codes are 0-255, so -1 indicates
+     * an unknown state rather than a specific failure or success.
      */
     public static function parse(array $result): CommandResponse
     {
@@ -23,9 +27,10 @@ class CommandResponseParser
                     errorOutput: $result['result']['stderr'] ?? '',
                 );
             } elseif (is_string($result['result'])) {
-                // String result with -1 exit code
+                // When Daytona returns -1, we can't determine the actual exit code
+                // Don't assume success or failure
                 return new CommandResponse(
-                    exitCode: 0, // Assume success if we got string output
+                    exitCode: -1, // Keep the -1 to indicate "unknown"
                     output: $result['result'],
                     errorOutput: '',
                 );

--- a/src/DTOs/CommandResponse.php
+++ b/src/DTOs/CommandResponse.php
@@ -47,4 +47,15 @@ class CommandResponse
     {
         return ! empty($this->errorOutput);
     }
+
+    /**
+     * Check if the exit code is known (i.e., not -1).
+     * 
+     * When Daytona API returns -1, it means the actual exit code couldn't be determined.
+     * Valid bash exit codes are 0-255.
+     */
+    public function hasKnownExitCode(): bool
+    {
+        return $this->exitCode >= 0;
+    }
 }

--- a/tests/Feature/CommandResponseParserTest.php
+++ b/tests/Feature/CommandResponseParserTest.php
@@ -55,7 +55,7 @@ it('parses string result with -1 exit code', function () {
 
     $parsed = CommandResponseParser::parse($response);
 
-    expect($parsed->exitCode)->toBe(0);
+    expect($parsed->exitCode)->toBe(-1);
     expect($parsed->output)->toBe('Simple string output');
     expect($parsed->errorOutput)->toBe('');
 });
@@ -94,6 +94,7 @@ it('provides helpful methods on CommandResponse', function () {
     expect($successResponse->failed())->toBeFalse();
     expect($successResponse->hasOutput())->toBeTrue();
     expect($successResponse->hasErrorOutput())->toBeFalse();
+    expect($successResponse->hasKnownExitCode())->toBeTrue();
 
     $failureResponse = CommandResponseParser::parse([
         'exitCode' => 1,
@@ -105,4 +106,31 @@ it('provides helpful methods on CommandResponse', function () {
     expect($failureResponse->failed())->toBeTrue();
     expect($failureResponse->hasOutput())->toBeFalse();
     expect($failureResponse->hasErrorOutput())->toBeTrue();
+    expect($failureResponse->hasKnownExitCode())->toBeTrue();
+});
+
+it('handles unknown exit code (-1) correctly', function () {
+    $unknownResponse = CommandResponseParser::parse([
+        'exitCode' => -1,
+        'result' => '',
+    ]);
+
+    expect($unknownResponse->exitCode)->toBe(-1);
+    expect($unknownResponse->isSuccessful())->toBeFalse();
+    expect($unknownResponse->failed())->toBeTrue();
+    expect($unknownResponse->hasKnownExitCode())->toBeFalse();
+    expect($unknownResponse->output)->toBe('');
+    expect($unknownResponse->errorOutput)->toBe('');
+});
+
+it('handles unknown exit code with output', function () {
+    $unknownResponse = CommandResponseParser::parse([
+        'exitCode' => -1,
+        'result' => 'Command output when exit code is unknown',
+    ]);
+
+    expect($unknownResponse->exitCode)->toBe(-1);
+    expect($unknownResponse->hasKnownExitCode())->toBeFalse();
+    expect($unknownResponse->hasOutput())->toBeTrue();
+    expect($unknownResponse->output)->toBe('Command output when exit code is unknown');
 });


### PR DESCRIPTION
## Summary
- Fixed CommandResponseParser to preserve -1 exit code instead of incorrectly assuming success
- Added `hasKnownExitCode()` method to CommandResponse for better error handling
- Updated documentation to explain exit code behavior

## Background
The Daytona API returns exit code -1 when it cannot determine the actual command exit code. This is not a valid bash exit code (which are 0-255), but rather an indicator of "unknown status".

Previously, the SDK incorrectly assumed that any string output with -1 meant success. This could lead to false positives where failed commands appeared successful.

## Changes
1. **CommandResponseParser**: Now preserves the -1 exit code instead of converting it to 0
2. **CommandResponse**: Added `hasKnownExitCode()` method that returns true only for valid exit codes (>= 0)
3. **Tests**: Updated existing test and added new tests for unknown exit code scenarios
4. **Documentation**: Added note explaining exit code behavior in README

## Impact
This is a breaking change for code that relies on the previous behavior where -1 was converted to 0. However, it provides more accurate command execution results and allows developers to handle unknown exit codes appropriately.

## Test plan
- [x] All existing tests pass
- [x] Added tests for unknown exit code handling
- [x] Verified hasKnownExitCode() works correctly