### PR TITLE
feat: add preview URL functionality to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,35 @@ $sandbox->waitUntilStarted(timeout: 120); // Wait up to 2 minutes
 $sandbox->stop()->waitUntilStopped();
 ```
 
+#### Preview URLs
+
+Access services running in your sandbox through preview URLs:
+
+```php
+// Get preview URL for a specific port
+$previewInfo = $sandbox->getPreviewLink(3000);
+
+echo "Preview URL: " . $previewInfo->url;
+echo "Access Token: " . $previewInfo->token;
+
+// For programmatic access (e.g., curl), use the authorization token:
+$response = Http::withHeaders([
+    'x-daytona-preview-token' => $previewInfo->token
+])->get($previewInfo->url);
+
+// Multiple ports example
+$ports = [3000, 8080, 5000];
+foreach ($ports as $port) {
+    $preview = $sandbox->getPreviewLink($port);
+    echo "Port {$port}: {$preview->url}\n";
+}
+```
+
+Preview URLs allow external access to services running in your sandbox:
+- **Public sandboxes**: URLs are publicly accessible
+- **Private sandboxes**: Require authentication token in `x-daytona-preview-token` header
+- **URL format**: `https://{port}-{sandboxId}.{runner-domain}`
+
 #### Error Handling
 
 The SDK provides specific exception types for different error scenarios:

--- a/src/DTOs/PortPreviewUrl.php
+++ b/src/DTOs/PortPreviewUrl.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ElliottLawson\Daytona\DTOs;
+
+class PortPreviewUrl
+{
+    public function __construct(
+        public readonly string $url,
+        public readonly string $token,
+        public readonly ?string $legacyProxyUrl = null,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            url: $data['url'],
+            token: $data['token'],
+            legacyProxyUrl: $data['legacyProxyUrl'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'url' => $this->url,
+            'token' => $this->token,
+            'legacyProxyUrl' => $this->legacyProxyUrl,
+        ], fn ($value) => $value !== null);
+    }
+}

--- a/src/DaytonaClient.php
+++ b/src/DaytonaClient.php
@@ -10,6 +10,7 @@ use ElliottLawson\Daytona\DTOs\FilePermissionsParams;
 use ElliottLawson\Daytona\DTOs\GitBranchesResponse;
 use ElliottLawson\Daytona\DTOs\GitHistoryResponse;
 use ElliottLawson\Daytona\DTOs\GitStatusResponse;
+use ElliottLawson\Daytona\DTOs\PortPreviewUrl;
 use ElliottLawson\Daytona\DTOs\ReplaceRequest;
 use ElliottLawson\Daytona\DTOs\ReplaceResult;
 use ElliottLawson\Daytona\DTOs\SandboxCreateParameters;
@@ -1074,6 +1075,47 @@ class DaytonaClient
 
             // Wait before next check
             usleep($checkInterval * 1000000); // Convert to microseconds
+        }
+    }
+
+    /**
+     * Get preview URL for a sandbox port.
+     *
+     * @param  string  $sandboxId  The sandbox ID
+     * @param  int  $port  The port number to get preview URL for
+     * @return PortPreviewUrl The preview URL information including URL and access token
+     *
+     * @throws ApiException If the API request fails
+     */
+    public function getPortPreviewUrl(string $sandboxId, int $port): PortPreviewUrl
+    {
+        try {
+            Log::debug('Getting preview URL for sandbox port', [
+                'sandboxId' => $sandboxId,
+                'port' => $port,
+            ]);
+
+            $response = $this->client()->get("sandbox/{$sandboxId}/ports/{$port}/preview-url");
+
+            if (! $response->successful()) {
+                throw ApiException::fromResponse($response, 'get preview URL');
+            }
+
+            $data = $response->json();
+            Log::debug('Preview URL retrieved successfully', [
+                'sandboxId' => $sandboxId,
+                'port' => $port,
+                'url' => $data['url'] ?? null,
+            ]);
+
+            return PortPreviewUrl::fromArray($data);
+        } catch (RequestException $e) {
+            Log::error('Failed to get preview URL for sandbox port', [
+                'sandboxId' => $sandboxId,
+                'port' => $port,
+                'error' => $e->getMessage(),
+            ]);
+            throw ApiException::requestFailed('get preview URL', $e->getMessage(), $e);
         }
     }
 }

--- a/src/Facades/Daytona.php
+++ b/src/Facades/Daytona.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \ElliottLawson\Daytona\DTOs\GitStatusResponse gitStatus(string $sandboxId, string $repoPath = '/workspace')
  * @method static \ElliottLawson\Daytona\DTOs\GitHistoryResponse gitHistory(string $sandboxId, string $repoPath = '/workspace')
  * @method static \ElliottLawson\Daytona\Sandbox sandboxFromResponse(\ElliottLawson\Daytona\DTOs\SandboxResponse $response)
+ * @method static \ElliottLawson\Daytona\DTOs\PortPreviewUrl getPortPreviewUrl(string $sandboxId, int $port)
  *
  * @see \ElliottLawson\Daytona\DaytonaClient
  */

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -320,4 +320,25 @@ class Sandbox
 
         return $results[0] ?? new ReplaceResult($file, false, 'No result returned');
     }
+
+    /**
+     * Get preview URL for a sandbox port.
+     *
+     * Retrieves the preview link for a sandbox at the specified port.
+     * The preview URL allows external access to services running in the sandbox.
+     *
+     * @param  int  $port  The port number to get preview URL for
+     * @return \ElliottLawson\Daytona\DTOs\PortPreviewUrl The preview URL information
+     *
+     * @throws \ElliottLawson\Daytona\Exceptions\ApiException If the API request fails
+     *
+     * @example
+     * $previewInfo = $sandbox->getPreviewLink(3000);
+     * echo "Preview URL: " . $previewInfo->url;
+     * echo "Access Token: " . $previewInfo->token;
+     */
+    public function getPreviewLink(int $port): \ElliottLawson\Daytona\DTOs\PortPreviewUrl
+    {
+        return $this->client->getPortPreviewUrl($this->id, $port);
+    }
 }

--- a/tests/Feature/PreviewUrlTest.php
+++ b/tests/Feature/PreviewUrlTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use ElliottLawson\Daytona\DaytonaClient;
+use ElliottLawson\Daytona\DTOs\Config;
+use ElliottLawson\Daytona\DTOs\PortPreviewUrl;
+use ElliottLawson\Daytona\Exceptions\ApiException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->sandboxId = 'test-sandbox-123';
+    $this->config = new Config(
+        apiKey: 'test-key',
+        apiUrl: 'https://api.daytona.io',
+        organizationId: 'test-org'
+    );
+    $this->client = new DaytonaClient($this->config);
+});
+
+it('can get preview url for sandbox port', function () {
+    // Arrange
+    $port = 3000;
+    $expectedUrl = 'https://3000-test-sandbox-123.h7890.daytona.work';
+    $expectedToken = 'vg5c0ylmcimr8b_v1ne0u6mdnvit6gc0';
+
+    Http::fake([
+        "*/sandbox/{$this->sandboxId}" => Http::response([
+            'id' => $this->sandboxId,
+            'state' => 'started',
+        ], 200),
+        "*/sandbox/{$this->sandboxId}/ports/{$port}/preview-url" => Http::response([
+            'url' => $expectedUrl,
+            'token' => $expectedToken,
+            'legacyProxyUrl' => 'https://3000-test-sandbox-123.runner.daytona.work',
+        ], 200),
+    ]);
+
+    // Act
+    $sandbox = $this->client->getSandboxById($this->sandboxId);
+    $previewInfo = $sandbox->getPreviewLink($port);
+
+    // Assert
+    expect($previewInfo)->toBeInstanceOf(PortPreviewUrl::class);
+    expect($previewInfo->url)->toBe($expectedUrl);
+    expect($previewInfo->token)->toBe($expectedToken);
+    expect($previewInfo->legacyProxyUrl)->toBe('https://3000-test-sandbox-123.runner.daytona.work');
+});
+
+it('can get preview url without legacy proxy url', function () {
+    // Arrange
+    $port = 8080;
+    $expectedUrl = 'https://8080-test-sandbox-123.h7890.daytona.work';
+    $expectedToken = 'another-token-123';
+
+    Http::fake([
+        "*/sandbox/{$this->sandboxId}" => Http::response([
+            'id' => $this->sandboxId,
+            'state' => 'started',
+        ], 200),
+        "*/sandbox/{$this->sandboxId}/ports/{$port}/preview-url" => Http::response([
+            'url' => $expectedUrl,
+            'token' => $expectedToken,
+        ], 200),
+    ]);
+
+    // Act
+    $sandbox = $this->client->getSandboxById($this->sandboxId);
+    $previewInfo = $sandbox->getPreviewLink($port);
+
+    // Assert
+    expect($previewInfo->url)->toBe($expectedUrl);
+    expect($previewInfo->token)->toBe($expectedToken);
+    expect($previewInfo->legacyProxyUrl)->toBeNull();
+});
+
+it('throws exception when preview url request fails', function () {
+    // Arrange
+    $port = 3000;
+
+    Http::fake([
+        "*/sandbox/{$this->sandboxId}" => Http::response([
+            'id' => $this->sandboxId,
+            'state' => 'started',
+        ], 200),
+        "*/sandbox/{$this->sandboxId}/ports/{$port}/preview-url" => Http::response([
+            'error' => 'Port not exposed',
+        ], 404),
+    ]);
+
+    // Act & Assert
+    $sandbox = $this->client->getSandboxById($this->sandboxId);
+
+    expect(fn () => $sandbox->getPreviewLink($port))
+        ->toThrow(ApiException::class, 'Resource not found');
+});
+
+it('handles server errors when getting preview url', function () {
+    // Arrange
+    $port = 3000;
+
+    Http::fake([
+        "*/sandbox/{$this->sandboxId}" => Http::response([
+            'id' => $this->sandboxId,
+            'state' => 'started',
+        ], 200),
+        "*/sandbox/{$this->sandboxId}/ports/{$port}/preview-url" => Http::response([
+            'error' => 'Internal server error',
+        ], 500),
+    ]);
+
+    // Act & Assert
+    $sandbox = $this->client->getSandboxById($this->sandboxId);
+
+    expect(fn () => $sandbox->getPreviewLink($port))
+        ->toThrow(ApiException::class, 'Server error');
+});
+
+it('port preview url dto can convert to and from array', function () {
+    // Arrange
+    $data = [
+        'url' => 'https://3000-sandbox-123.daytona.work',
+        'token' => 'test-token-123',
+        'legacyProxyUrl' => 'https://3000-sandbox-123.runner.daytona.work',
+    ];
+
+    // Act
+    $dto = PortPreviewUrl::fromArray($data);
+    $array = $dto->toArray();
+
+    // Assert
+    expect($dto->url)->toBe($data['url']);
+    expect($dto->token)->toBe($data['token']);
+    expect($dto->legacyProxyUrl)->toBe($data['legacyProxyUrl']);
+    expect($array)->toBe($data);
+});
+
+it('port preview url dto filters null values in to array', function () {
+    // Arrange
+    $data = [
+        'url' => 'https://3000-sandbox-123.daytona.work',
+        'token' => 'test-token-123',
+    ];
+
+    // Act
+    $dto = PortPreviewUrl::fromArray($data);
+    $array = $dto->toArray();
+
+    // Assert
+    expect($array)->not->toHaveKey('legacyProxyUrl');
+    expect($array)->toHaveCount(2);
+});

--- a/tests/Integration/SandboxPreviewUrlTest.php
+++ b/tests/Integration/SandboxPreviewUrlTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace ElliottLawson\Daytona\Tests\Integration;
+
+use ElliottLawson\Daytona\DTOs\PortPreviewUrl;
+
+class SandboxPreviewUrlTest extends IntegrationTestCase
+{
+    /** @test */
+    public function it_can_get_preview_url_for_sandbox_port()
+    {
+        // Skip if not in integration test mode
+        if (! $this->shouldRunIntegrationTests()) {
+            $this->markTestSkipped('Integration tests are not enabled.');
+        }
+
+        // Create a sandbox for testing
+        $sandbox = $this->createTestSandbox();
+
+        try {
+            // Act - Get preview URL for port 3000
+            $previewInfo = $sandbox->getPreviewLink(3000);
+
+            // Assert
+            $this->assertInstanceOf(PortPreviewUrl::class, $previewInfo);
+            $this->assertNotEmpty($previewInfo->url);
+            $this->assertNotEmpty($previewInfo->token);
+
+            // Verify URL format matches expected pattern
+            $this->assertMatchesRegularExpression(
+                '/^https:\/\/3000-[a-zA-Z0-9-]+\.[a-zA-Z0-9.-]+$/',
+                $previewInfo->url
+            );
+
+            // Token should be a non-empty string
+            $this->assertIsString($previewInfo->token);
+            $this->assertGreaterThan(10, strlen($previewInfo->token));
+
+            // Log the preview URL for manual testing if needed
+            echo "\nPreview URL: {$previewInfo->url}\n";
+            echo "Access Token: {$previewInfo->token}\n";
+
+            if ($previewInfo->legacyProxyUrl) {
+                echo "Legacy Proxy URL: {$previewInfo->legacyProxyUrl}\n";
+            }
+        } finally {
+            // Cleanup
+            $this->cleanupSandbox($sandbox);
+        }
+    }
+
+    /** @test */
+    public function it_can_get_preview_urls_for_multiple_ports()
+    {
+        // Skip if not in integration test mode
+        if (! $this->shouldRunIntegrationTests()) {
+            $this->markTestSkipped('Integration tests are not enabled.');
+        }
+
+        // Create a sandbox for testing
+        $sandbox = $this->createTestSandbox();
+
+        try {
+            // Test multiple common ports
+            $ports = [3000, 8080, 8000, 5000];
+            $previewUrls = [];
+
+            foreach ($ports as $port) {
+                $previewInfo = $sandbox->getPreviewLink($port);
+                $previewUrls[$port] = $previewInfo;
+
+                // Assert each preview URL is unique and properly formatted
+                $this->assertNotEmpty($previewInfo->url);
+                $this->assertStringContainsString((string) $port, $previewInfo->url);
+                $this->assertStringContainsString($sandbox->getId(), $previewInfo->url);
+            }
+
+            // Ensure all URLs are unique
+            $urls = array_map(fn ($info) => $info->url, $previewUrls);
+            $this->assertCount(count($ports), array_unique($urls));
+
+            // Tokens might be the same for all ports in the same sandbox
+            $tokens = array_map(fn ($info) => $info->token, $previewUrls);
+            $this->assertNotEmpty($tokens[0]);
+        } finally {
+            // Cleanup
+            $this->cleanupSandbox($sandbox);
+        }
+    }
+
+    /** @test */
+    public function it_handles_preview_url_for_non_standard_ports()
+    {
+        // Skip if not in integration test mode
+        if (! $this->shouldRunIntegrationTests()) {
+            $this->markTestSkipped('Integration tests are not enabled.');
+        }
+
+        // Create a sandbox for testing
+        $sandbox = $this->createTestSandbox();
+
+        try {
+            // Test edge case ports
+            $ports = [3001, 9999, 4000];
+
+            foreach ($ports as $port) {
+                $previewInfo = $sandbox->getPreviewLink($port);
+
+                // Assert
+                $this->assertInstanceOf(PortPreviewUrl::class, $previewInfo);
+                $this->assertStringContainsString((string) $port, $previewInfo->url);
+                $this->assertNotEmpty($previewInfo->token);
+            }
+        } finally {
+            // Cleanup
+            $this->cleanupSandbox($sandbox);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds preview URL functionality to the Daytona PHP SDK, allowing users to get external access URLs for services running in their sandboxes.

## Changes

- **New DTO**: Added `PortPreviewUrl` class with URL, token, and optional legacy proxy URL properties
- **Client Method**: Added `getPortPreviewUrl()` to `DaytonaClient` for API calls
- **Sandbox Method**: Added `getPreviewLink()` convenience method to `Sandbox` class
- **Facade Support**: Updated `Daytona` facade to include the new method
- **Documentation**: Updated README with preview URL usage examples
- **Tests**: Added comprehensive unit and integration tests

## Usage

```php
// Get preview URL for a specific port
$previewInfo = $sandbox->getPreviewLink(3000);

echo "Preview URL: " . $previewInfo->url;
echo "Access Token: " . $previewInfo->token;

// For programmatic access (private sandboxes)
$response = Http::withHeaders([
    'x-daytona-preview-token' => $previewInfo->token
])->get($previewInfo->url);
```

## Implementation Details

The implementation follows the same pattern as the TypeScript SDK:
- Endpoint: `GET /sandbox/{sandboxId}/ports/{port}/preview-url`
- Returns URL and authentication token
- Supports optional legacy proxy URL for backward compatibility

## Testing

- ✅ All unit tests passing
- ✅ Integration tests included
- ✅ Code formatted with Laravel Pint

## Related Documentation

Based on the Daytona documentation:
- Public sandboxes: URLs are publicly accessible
- Private sandboxes: Require authentication token in `x-daytona-preview-token` header
- URL format: `https://{port}-{sandboxId}.{runner-domain}`