### PR TITLE
fix: correct parameter order in Session::executeCommand

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -33,8 +33,9 @@ class Session
     ): SessionCommand {
         $request = new SessionExecuteRequest(
             command: $command,
-            cwd: $cwd,
-            env: $env
+            runAsync: $runAsync,
+            env: $env ?? [],
+            cwd: $cwd
         );
 
         $response = $this->client->executeSessionCommand($this->sandboxId, $this->id, $request);


### PR DESCRIPTION
## Summary
Fixes a bug in the `Session::executeCommand()` method where the `runAsync` parameter was not being passed to `SessionExecuteRequest`, causing all async commands to run synchronously.

## The Issue
The implementing AI discovered that `Session::executeCommand()` was passing parameters in the wrong order to `SessionExecuteRequest`:
- Missing `runAsync` parameter entirely
- This caused `runAsync: true` to be ignored, defaulting to `false`
- Could also cause type errors if `env` was null

## The Fix
```php
// Before (incorrect)
$request = new SessionExecuteRequest(
    command: $command,
    cwd: $cwd,        // Wrong position
    env: $env         // Could be null, causing type error
);

// After (correct)
$request = new SessionExecuteRequest(
    command: $command,
    runAsync: $runAsync,    // Now properly passed
    env: $env ?? [],        // Defaults to empty array
    cwd: $cwd               // Correct position
);
```

## Testing
- All existing feature tests pass
- The fix ensures async commands work correctly when `runAsync: true` is specified
- Prevents type errors by ensuring `env` is always an array

## Impact
This bug would have affected any code trying to use async command execution through the `Session` class, causing commands to always run synchronously regardless of the `runAsync` parameter.